### PR TITLE
fix: added html truncation and simplified logs

### DIFF
--- a/src/lib/server/repositories/TestNodeRepository.js
+++ b/src/lib/server/repositories/TestNodeRepository.js
@@ -4,17 +4,19 @@ export class TestNodeRepository extends BaseRepository {
 	static COLLECTION = 'toolgankelijk_test_node';
 
 	async storeTestNode(testNode) {
-		const failureSummary = String(testNode.failureSummary ?? '');
-		console.debug('Debug test node payload:', {
-			testId: testNode.testId,
-			target: testNode.target,
-			failureSummaryLength: failureSummary.length,
-			failureSummaryPreview: failureSummary.slice(0, 200)
-		});
+		let failureSummary = String(testNode.failureSummary ?? '');
+		if (failureSummary.length > 1000) {
+			failureSummary = failureSummary.slice(0, 997) + '...';
+		}
 
+		// Truncate html to 255 characters to match Directus max_length
+		let html = String(testNode.html ?? '');
+		if (html.length > 255) {
+			html = html.slice(0, 252) + '...';
+		}
 		const createdNode = await this.create(TestNodeRepository.COLLECTION, {
 			test_id: testNode.testId,
-			html: testNode.html,
+			html: html,
 			target: testNode.target,
 			failure_summary: failureSummary
 		});

--- a/src/routes/api/allUrls/+server.js
+++ b/src/routes/api/allUrls/+server.js
@@ -20,6 +20,7 @@ async function validatePayload(request) {
 
 /** Starts the all-URLs audit stream. */
 export async function POST({ request }) {
+	console.info('[allUrls] Audit request received');
 	try {
 		// validation
 		const invalidCheck = await validatePayload(request);
@@ -31,10 +32,10 @@ export async function POST({ request }) {
 					SseService.push(session, update, update.type ?? 'message');
 				}
 			})().catch((err) => {
+				console.error('Audit failed with error:', err);
 				const body = {
 					type: 'audit_failed',
-					message: 'Er is een fout opgetreden tijdens de audit!',
-					details: err instanceof Error ? err.message : String(err)
+					message: 'Er is een fout opgetreden tijdens de audit!'
 				};
 				SseService.push(session, body, body.type);
 			});
@@ -43,8 +44,7 @@ export async function POST({ request }) {
 		console.error('Error during audit:', err);
 		return json(
 			{
-				error: 'Er is een fout opgetreden tijdens de audit!',
-				details: err instanceof Error ? err.message : String(err)
+				error: 'Er is een fout opgetreden tijdens de audit!'
 			},
 			{ status: 500 }
 		);

--- a/src/routes/api/specifiedUrls/+server.js
+++ b/src/routes/api/specifiedUrls/+server.js
@@ -43,6 +43,7 @@ function validatePayload(body) {
 
 /** Starts a partner audit stream. */
 export async function POST({ request }) {
+	console.info('[specifiedUrls] Audit request received');
 	let body;
 	try {
 		body = await request.json();
@@ -63,10 +64,10 @@ export async function POST({ request }) {
 					SseService.push(session, update, update.type ?? 'message');
 				}
 			})().catch((err) => {
+				console.error('Audit failed with error:', err);
 				const body = {
 					type: 'audit_failed',
-					message: 'Er is een fout opgetreden tijdens de audit!',
-					details: err instanceof Error ? err.message : String(err)
+					message: 'Er is een fout opgetreden tijdens de audit!'
 				};
 				SseService.push(session, body, body.type);
 			});
@@ -75,8 +76,7 @@ export async function POST({ request }) {
 		console.error('Error during audit:', err);
 		return json(
 			{
-				error: 'Er is een fout opgetreden tijdens de audit!',
-				details: err instanceof Error ? err.message : String(err)
+				error: 'Er is een fout opgetreden tijdens de audit!'
 			},
 			{ status: 500 }
 		);


### PR DESCRIPTION
## What does this change?

  This merge request fixes a issue that occurs when a audit targets a large html, and cleans up logging.
                                                               
  • Fix audit failures: HTML snippets are truncated before being saved, This prevents audits from crashing when checking elements with large HTML structures.
  • Clean up error messages: Simplified error handling to return a generic error message to the
  client, keeping technical error details in the server logs.                                   
  • Add request logging: Added startup logs to the audit endpoints to help track when audits   
  start.                         